### PR TITLE
Add basic CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+
+      - run: make test
+
+      - run: make bin


### PR DESCRIPTION
Add a super-simple CI step for PRs, that runs `make test` and `make bin` (which includes `fmt` and `vet`.

Github action best practices are followed - the permssions passed to the actions are minimised to just repo read permissions needed, and the actions are pinned to SHA hashes so that they're resistant to action supply chain attacks such as last month's trivy attack. This does mean the SHAs should be checked and updated occasionally, but for an action this simple that shouldn't be needed often or urgently

Closes issue #5 